### PR TITLE
added style-loader css-loader to webpack config

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -40,6 +40,10 @@ module.exports = {
             ]
           }
         }
+      },
+      {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"],
       }
     ]
   },


### PR DESCRIPTION
Not having this was causing my application to fail – CSS is required by the custom vis, and by (not used?) DashboardExternalFilters component.

That said – I think Nick or Russ said having the css loader was causing issues? Would love to understand this if so